### PR TITLE
Support IAM role-based access to S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,14 @@ c = get_config()
 
 # Tell Jupyter to use S3ContentsManager for all storage.
 c.NotebookApp.contents_manager_class = S3ContentsManager
-c.S3ContentsManager.access_key_id = ""
-c.S3ContentsManager.secret_access_key = ""
+c.S3ContentsManager.access_key_id = <IAM Access Key ID>
+c.S3ContentsManager.secret_access_key = <IAM Secret Access Key>
 c.S3ContentsManager.bucket_name = ""
 ```
+
+Note that it is also possible to use IAM Role-based access to the S3 bucket from an Amazon EC2 instance; to do that,
+just leave ```access_key_id``` and ```secret_access_key``` set to their default values (```None```), and ensure that
+the EC2 instance has an IAM role which provides sufficient permissions for the bucket and the operations necessary.
 
 Example for `play.minio.io:9000`:
 

--- a/s3contents/s3fs.py
+++ b/s3contents/s3fs.py
@@ -10,8 +10,8 @@ from s3contents.ipycompat import HasTraits, Unicode
 
 class S3FS(HasTraits):
 
-    access_key_id = Unicode(help="S3/AWS access key ID").tag(config=True, env="JPYNB_S3_ACCESS_KEY_ID")
-    secret_access_key = Unicode(help="S3/AWS secret access key").tag(config=True, env="JPYNB_S3_SECRET_ACCESS_KEY")
+    access_key_id = Unicode(help="S3/AWS access key ID", allow_none=True, default_value=None).tag(config=True, env="JPYNB_S3_ACCESS_KEY_ID")
+    secret_access_key = Unicode(help="S3/AWS secret access key", allow_none=True, default_value=None).tag(config=True, env="JPYNB_S3_SECRET_ACCESS_KEY")
 
     bucket_name = Unicode("notebooks", help="The").tag(config=True, env="JPYNB_S3_BUCKET_NAME")
     region_name = Unicode("us-east-1", help="Region Name").tag(config=True, env="JPYNB_S3_REGION_NAME")

--- a/s3contents/s3manager.py
+++ b/s3contents/s3manager.py
@@ -16,8 +16,8 @@ NBFORMAT_VERSION = 4
 
 class S3ContentsManager(ContentsManager, HasTraits):
 
-    access_key_id = Unicode(help="S3/AWS access key ID").tag(config=True, env="JPYNB_S3_ACCESS_KEY_ID")
-    secret_access_key = Unicode(help="S3/AWS secret access key").tag(config=True, env="JPYNB_S3_SECRET_ACCESS_KEY")
+    access_key_id = Unicode(help="S3/AWS access key ID", allow_none=True, default_value=None).tag(config=True, env="JPYNB_S3_ACCESS_KEY_ID")
+    secret_access_key = Unicode(help="S3/AWS secret access key", allow_none=True, default_value=None).tag(config=True, env="JPYNB_S3_SECRET_ACCESS_KEY")
 
     bucket_name = Unicode("notebooks", help="The").tag(config=True, env="JPYNB_S3_BUCKET_NAME")
     region_name = Unicode("us-east-1", help="Region Name").tag(config=True, env="JPYNB_S3_REGION_NAME")


### PR DESCRIPTION
This patch changes s3fs.py and s3manager.py to allow 'None' as valid values
for 'access_key_id' and 'secret_access_key'. When using IAM role-based access to S3
buckets, the application must not specify any value for these two items at all.

The patch also changes the default value of these configuration items to 'None', as
that can actually be a useful value (the previous default, an empty string, would never
be an useful value). With this change, if the user fails to configure one (or both)
of these values, the error they receive will indicate that no value was supplied,
instead of indicating that the Access Key ID could not be found (or that the Secret
Access Key is invalid).

This fixes issue #4.