### PR TITLE
Add python 2.7 to the travis test matrix

### DIFF
--- a/.ci/install_python.sh
+++ b/.ci/install_python.sh
@@ -15,3 +15,8 @@ conda --version
 conda create -n test python=$TRAVIS_PYTHON_VERSION
 export PATH=$HOME/miniconda/envs/test/bin:$PATH
 pip install nose pytest pytest-cov python-coveralls
+
+if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]
+then
+    pip install mock
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ notifications:
 matrix:
   include:
     - python: "3.5"
+    - python: "2.7"
+
 
 before_install:
   - pwd


### PR DESCRIPTION
As s3contents works on python 2.7, it should also be tested on python 2.7, so that this stays the case.