### PR TITLE
Refactor s3fs so that it is easier to add another backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ target/
 .ipynb_checkpoints
 
 s3-data
+
+# PyCharm
+.idea/

--- a/s3contents/basefs.py
+++ b/s3contents/basefs.py
@@ -2,7 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import six
+import datetime
 from s3contents.ipycompat import HasTraits, Unicode
+
+DUMMY_CREATED_DATE = datetime.datetime.fromtimestamp(0)
 
 
 class BaseFS(HasTraits):
@@ -75,6 +78,15 @@ class BaseFS(HasTraits):
         else:
             files = list(files)
         return map(self.as_path, files)
+
+    def lstat(self, path):
+        key = self.as_key(path)
+        if not self.isfile(path):
+            raise NoSuchFileException(self.as_path(key))
+
+        info = {}
+        info["ST_MTIME"] = DUMMY_CREATED_DATE
+        return info
 
     def as_key(self, path):
         """Utility: Make a path a S3 key

--- a/s3contents/basefs.py
+++ b/s3contents/basefs.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import six
+from s3contents.ipycompat import HasTraits, Unicode
+
+
+class BaseFS(HasTraits):
+    delimiter = Unicode("/", help="Path delimiter").tag(config=True)
+    prefix = Unicode("", help="Prefix path inside the specified bucket").tag(config=True)
+    dir_keep_file = Unicode(
+        ".s3keep", help="Empty file to create when creating directories").tag(config=True)
+
+    def __init__(self, log, **kwargs):
+        super(BaseFS, self).__init__(**kwargs)
+        self.log = log
+
+    def get_keys(self, prefix=""):
+        raise NotImplementedError
+
+    def isfile(self, path):
+        raise NotImplementedError
+
+    def isdir(self, path):
+        self.log.debug("S3contents[S3FS] Checking if `%s` is a directory", path)
+        key = self.as_key(path)
+        if key == "":
+            return True
+        if not key.endswith(self.delimiter):
+            key = key + self.delimiter
+        if key == "":
+            return True
+        is_dir = len(self.get_keys(prefix=key)) > 0
+        self.log.debug("S3contents[S3FS] `%s` is a directory: %s", path, is_dir)
+        return is_dir
+
+    def mv(self, old_path, new_path):
+        self.cp(old_path, new_path)
+        self.rm(old_path)
+
+    def cp(self, old_path, new_path):
+        raise NotImplementedError
+
+    def rm(self, path):
+        raise NotImplementedError
+
+    def mkdir(self, path):
+        self.log.debug("S3contents[S3FS] Making dir: `%s`", path)
+        if self.isfile(path):
+            self.log.debug("S3contents[S3FS] File `%s` already exists, not creating anything", path)
+        elif self.isdir(path):
+            self.log.debug("S3contents[S3FS] Directory `%s` already exists, not creating anything",
+                           path)
+        else:
+            obj_path = self.join(path, self.dir_keep_file)
+            self.write(obj_path, "")
+
+    def read(self, path):
+        raise NotImplementedError
+
+    def write(self, path, content):
+        raise NotImplementedError
+
+    def listdir(self, path="", with_prefix=False):
+        self.log.debug("S3contents[S3FS] Listing directory: `%s`", path)
+        prefix = self.as_key(path)
+        fnames = self.get_keys(prefix=prefix)
+        fnames_no_prefix = [self.remove_prefix(fname, prefix=prefix) for fname in fnames]
+        fnames_no_prefix = [fname.lstrip(self.delimiter) for fname in fnames_no_prefix]
+        files = set(fname.split(self.delimiter)[0] for fname in fnames_no_prefix)
+        if with_prefix:
+            files = [
+                self.join(prefix.strip(self.delimiter), f).strip(self.delimiter) for f in files
+            ]
+        else:
+            files = list(files)
+        return map(self.as_path, files)
+
+    def as_key(self, path):
+        """Utility: Make a path a S3 key
+        """
+        path_ = self.abspath(path)
+        self.log.debug("S3contents[S3FS] Understanding `%s` as `%s`", path, path_)
+        if isinstance(path_, six.string_types):
+            return path_.strip(self.delimiter)
+        if isinstance(path_, list):
+            return [self.as_key(item) for item in path_]
+
+    def as_path(self, key):
+        """Utility: Make a S3 key a path
+        """
+        key_ = self.remove_prefix(key)
+        if isinstance(key_, six.string_types):
+            return key_.strip(self.delimiter)
+
+    def remove_prefix(self, text, prefix=None):
+        """Utility: remove a prefix from a string
+        """
+        if prefix is None:
+            prefix = self.prefix
+        if text.startswith(prefix):
+            return text[len(prefix):].strip("/")
+        return text.strip("/")
+
+    def join(self, *args):
+        """Utility: join using the delimiter
+        """
+        return self.delimiter.join(args)
+
+    def abspath(self, path):
+        """Utility: Return a normalized absolutized version of the pathname path
+        Basically prepends the path with the prefix
+        """
+        path = path.strip("/")
+        if self.prefix:
+            path = self.join(self.prefix, path)
+        return path.strip("/")
+
+
+class NoSuchFileException(Exception):
+    def __init__(self, path, *args):
+        super(NoSuchFileException, self).__init__(*args)
+        self.path = path

--- a/s3contents/basefs.py
+++ b/s3contents/basefs.py
@@ -22,7 +22,7 @@ class BaseFS(HasTraits):
         raise NotImplementedError
 
     def isdir(self, path):
-        self.log.debug("S3contents[S3FS] Checking if `%s` is a directory", path)
+        self.log.debug("S3contents[BaseFS] Checking if `%s` is a directory", path)
         key = self.as_key(path)
         if key == "":
             return True
@@ -31,7 +31,7 @@ class BaseFS(HasTraits):
         if key == "":
             return True
         is_dir = len(self.get_keys(prefix=key)) > 0
-        self.log.debug("S3contents[S3FS] `%s` is a directory: %s", path, is_dir)
+        self.log.debug("S3contents[BaseFS] `%s` is a directory: %s", path, is_dir)
         return is_dir
 
     def mv(self, old_path, new_path):
@@ -45,11 +45,11 @@ class BaseFS(HasTraits):
         raise NotImplementedError
 
     def mkdir(self, path):
-        self.log.debug("S3contents[S3FS] Making dir: `%s`", path)
+        self.log.debug("S3contents[BaseFS] Making dir: `%s`", path)
         if self.isfile(path):
-            self.log.debug("S3contents[S3FS] File `%s` already exists, not creating anything", path)
+            self.log.debug("S3contents[BaseFS] File `%s` already exists, not creating anything", path)
         elif self.isdir(path):
-            self.log.debug("S3contents[S3FS] Directory `%s` already exists, not creating anything",
+            self.log.debug("S3contents[BaseFS] Directory `%s` already exists, not creating anything",
                            path)
         else:
             obj_path = self.join(path, self.dir_keep_file)
@@ -62,7 +62,7 @@ class BaseFS(HasTraits):
         raise NotImplementedError
 
     def listdir(self, path="", with_prefix=False):
-        self.log.debug("S3contents[S3FS] Listing directory: `%s`", path)
+        self.log.debug("S3contents[BaseFS] Listing directory: `%s`", path)
         prefix = self.as_key(path)
         fnames = self.get_keys(prefix=prefix)
         fnames_no_prefix = [self.remove_prefix(fname, prefix=prefix) for fname in fnames]
@@ -80,7 +80,7 @@ class BaseFS(HasTraits):
         """Utility: Make a path a S3 key
         """
         path_ = self.abspath(path)
-        self.log.debug("S3contents[S3FS] Understanding `%s` as `%s`", path, path_)
+        self.log.debug("S3contents[BaseFS] Understanding `%s` as `%s`", path, path_)
         if isinstance(path_, six.string_types):
             return path_.strip(self.delimiter)
         if isinstance(path_, list):

--- a/s3contents/s3fs.py
+++ b/s3contents/s3fs.py
@@ -1,14 +1,14 @@
 """
 Utilities to make S3 look like a regular file system
 """
-import six
 import boto3
 from botocore.client import Config
 
-from s3contents.ipycompat import HasTraits, Unicode
+from s3contents.ipycompat import Unicode
+from s3contents.basefs import BaseFS, NoSuchFileException
 
 
-class S3FS(HasTraits):
+class S3FS(BaseFS):
 
     access_key_id = Unicode(
         help="S3/AWS access key ID", allow_none=True, default_value=None).tag(
@@ -26,15 +26,10 @@ class S3FS(HasTraits):
     bucket_name = Unicode(
         "notebooks", help="Bucket name to store notebooks").tag(
             config=True, env="JPYNB_S3_BUCKET_NAME")
-    prefix = Unicode("", help="Prefix path inside the specified bucket").tag(config=True)
     signature_version = Unicode(help="").tag(config=True)
-    delimiter = Unicode("/", help="Path delimiter").tag(config=True)
-
-    dir_keep_file = Unicode(
-        ".s3keep", help="Empty file to create when creating directories").tag(config=True)
 
     def __init__(self, log, **kwargs):
-        super(S3FS, self).__init__(**kwargs)
+        super(S3FS, self).__init__(log, **kwargs)
         self.log = log
 
         config = None
@@ -69,52 +64,16 @@ class S3FS(HasTraits):
             ret.append(obj.key)
         return ret
 
-    def listdir(self, path="", with_prefix=False):
-        self.log.debug("S3contents[S3FS] Listing directory: `%s`", path)
-        prefix = self.as_key(path)
-        fnames = self.get_keys(prefix=prefix)
-        fnames_no_prefix = [self.remove_prefix(fname, prefix=prefix) for fname in fnames]
-        fnames_no_prefix = [fname.lstrip(self.delimiter) for fname in fnames_no_prefix]
-        files = set(fname.split(self.delimiter)[0] for fname in fnames_no_prefix)
-        if with_prefix:
-            files = [
-                self.join(prefix.strip(self.delimiter), f).strip(self.delimiter) for f in files
-            ]
-        else:
-            files = list(files)
-        return map(self.as_path, files)
-
     def isfile(self, path):
         self.log.debug("S3contents[S3FS] Checking if `%s` is a file", path)
         key = self.as_key(path)
-        is_file = None
-        if key == "":
-            is_file = False
         try:
             self.client.head_object(Bucket=self.bucket_name, Key=key)
             is_file = True
-        except Exception as e:
+        except Exception:
             is_file = False
         self.log.debug("S3contents[S3FS] `%s` is a file: %s", path, is_file)
         return is_file
-
-    def isdir(self, path):
-        self.log.debug("S3contents[S3FS] Checking if `%s` is a directory", path)
-        key = self.as_key(path)
-        if key == "":
-            return True
-        if not key.endswith(self.delimiter):
-            key = key + self.delimiter
-        if key == "":
-            return True
-        objs = list(self.bucket.objects.filter(Prefix=key))
-        is_dir = len(objs) > 0
-        self.log.debug("S3contents[S3FS] `%s` is a directory: %s", path, is_dir)
-        return is_dir
-
-    def mv(self, old_path, new_path):
-        self.cp(old_path, new_path)
-        self.rm(old_path)
 
     def cp(self, old_path, new_path):
         self.log.debug("S3contents[S3FS] Copy `%s` to `%s`", old_path, new_path)
@@ -144,21 +103,10 @@ class S3FS(HasTraits):
                 objects_to_delete.append({"Key": obj.key})
             self.bucket.delete_objects(Delete={"Objects": objects_to_delete})
 
-    def mkdir(self, path):
-        self.log.debug("S3contents[S3FS] Making dir: `%s`", path)
-        if self.isfile(path):
-            self.log.debug("S3contents[S3FS] File `%s` already exists, not creating anything", path)
-        elif self.isdir(path):
-            self.log.debug("S3contents[S3FS] Directory `%s` already exists, not creating anything",
-                           path)
-        else:
-            obj_path = self.join(path, self.dir_keep_file)
-            self.write(obj_path, "")
-
     def read(self, path):
         key = self.as_key(path)
         if not self.isfile(path):
-            raise NoSuchFile(self.as_path(key))
+            raise NoSuchFileException(self.as_path(key))
         obj = self.resource.Object(self.bucket_name, key)
         text = obj.get()["Body"].read().decode("utf-8")
         return text
@@ -176,54 +124,3 @@ class S3FS(HasTraits):
     def write(self, path, content):
         key = self.as_key(path)
         self.client.put_object(Bucket=self.bucket_name, Key=key, Body=content)
-
-    def as_key(self, path):
-        """Utility: Make a path a S3 key
-        """
-        path_ = self.abspath(path)
-        self.log.debug("S3contents[S3FS] Understanding `%s` as `%s`", path, path_)
-        if isinstance(path_, six.string_types):
-            return path_.strip(self.delimiter)
-        if isinstance(path_, list):
-            return [self.as_key(item) for item in path_]
-
-    def as_path(self, key):
-        """Utility: Make a S3 key a path
-        """
-        key_ = self.remove_prefix(key)
-        if isinstance(key_, six.string_types):
-            return key_.strip(self.delimiter)
-
-    def remove_prefix(self, text, prefix=None):
-        """Utility: remove a prefix from a string
-        """
-        if prefix is None:
-            prefix = self.prefix
-        if text.startswith(prefix):
-            return text[len(prefix):].strip("/")
-        return text.strip("/")
-
-    def join(self, *args):
-        """Utility: join using the delimiter
-        """
-        return self.delimiter.join(args)
-
-    def abspath(self, path):
-        """Utility: Return a normalized absolutized version of the pathname path
-        Basically prepends the path with the prefix
-        """
-        path = path.strip("/")
-        if self.prefix:
-            path = self.join(self.prefix, path)
-        return path.strip("/")
-
-
-class S3FSError(Exception):
-    pass
-
-
-class NoSuchFile(S3FSError):
-
-    def __init__(self, path, *args, **kwargs):
-        super(NoSuchFile, self).__init__(*args, **kwargs)
-        self.path = path

--- a/s3contents/s3manager.py
+++ b/s3contents/s3manager.py
@@ -5,7 +5,8 @@ import datetime
 
 from tornado.web import HTTPError
 
-from s3contents.s3fs import S3FS, S3FSError, NoSuchFile
+from s3contents.s3fs import S3FS
+from s3contents.basefs import NoSuchFileException
 from s3contents.ipycompat import ContentsManager
 from s3contents.ipycompat import HasTraits, Unicode
 from s3contents.ipycompat import reads, from_dict, GenericFileCheckpoints
@@ -167,10 +168,8 @@ class S3ContentsManager(ContentsManager, HasTraits):
         if content:
             try:
                 content = self.s3fs.read(path)
-            except NoSuchFile as e:
+            except NoSuchFileException as e:
                 self.no_such_entity(e.path)
-            except S3FSError as e:
-                self.do_error(str(e), 500)
             model["format"] = format or "text"
             model["content"] = content
             model["mimetype"] = mimetypes.guess_type(path)[0] or "text/plain"

--- a/s3contents/s3manager.py
+++ b/s3contents/s3manager.py
@@ -1,17 +1,15 @@
 import os
 import json
 import mimetypes
-import datetime
 
 from tornado.web import HTTPError
 
 from s3contents.s3fs import S3FS
-from s3contents.basefs import NoSuchFileException
+from s3contents.basefs import NoSuchFileException, DUMMY_CREATED_DATE
 from s3contents.ipycompat import ContentsManager
 from s3contents.ipycompat import HasTraits, Unicode
 from s3contents.ipycompat import reads, from_dict, GenericFileCheckpoints
 
-DUMMY_CREATED_DATE = datetime.datetime.fromtimestamp(0)
 NBFORMAT_VERSION = 4
 
 


### PR DESCRIPTION
Hi,

as alluded in #8 we want to add support for non-S3 backends to s3contents.
After quite some time, we finally can tackle this.

As a first step, I refactored common code needed for all backends into a basefs, which is independent from the actual interface to S3.

This does not solve the problem of configuration (I do not have a good idea on that one currently :/).
I also do not think that the logging is very nice, as every log message includes the class it is living in, making refactoring harder. Short of dropping the class name, I do not have a good idea how to solve that either.

If this PR is not the direction you're looking to go in I'm willing to work with you to get it into an acceptable state. 