### PR TITLE
Update README.md to reflect bucket_name -> bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ c = get_config()
 c.NotebookApp.contents_manager_class = S3ContentsManager
 c.S3ContentsManager.access_key_id = <AWS Access Key ID / IAM Access Key ID>
 c.S3ContentsManager.secret_access_key = <AWS Secret Access Key / IAM Secret Access Key>
-c.S3ContentsManager.bucket_name = "<bucket-name>>"
+c.S3ContentsManager.bucket = "<bucket-name>>"
 ```
 
 Example for `play.minio.io:9000`:


### PR DESCRIPTION
Recent updates cause Jupyter to fail if bucket_name is used in the config. This updates the README to reflect this.