### PR TITLE
support ipython 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,6 @@ script:
 
 after_success:
   - coveralls
+
+after_failure:
+  - cat /tmp/minio.log

--- a/ci/start_minio.sh
+++ b/ci/start_minio.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # go get -u github.com/minio/minio
-wget https://dl.minio.io/server/minio/release/linux-amd64/minio
+curl https://dl.minio.io/server/minio/release/linux-amd64/archive/minio.RELEASE.2018-06-29T02-11-29Z -o minio
 chmod +x minio
 
 export MINIO_ACCESS_KEY=access-key

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 jupyter
+ipykernel<5.*
 boto3
 requests
 s3fs==0.1.5

--- a/s3contents/ipycompat.py
+++ b/s3contents/ipycompat.py
@@ -5,7 +5,7 @@ Taken from: https://github.com/quantopian/pgcontents/blob/master/pgcontents/util
 """
 import IPython
 
-SUPPORTED_VERSIONS = {3, 4, 5, 6}
+SUPPORTED_VERSIONS = {3, 4, 5, 6, 7}
 IPY_MAJOR = IPython.version_info[0]
 if IPY_MAJOR not in SUPPORTED_VERSIONS:
     raise ImportError("IPython version %d is not supported." % IPY_MAJOR)


### PR DESCRIPTION
Preliminary testing at least with S3 is working out well.

This did strike me as strange to check based on ipython versions rather than notebook server versions. Anywho, this adapts the work to the latest and greatest.