### PR TITLE
Adding a way do a custom boto3 instantiation to s3contents (for refreshing AWS keys)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ session_credentials = RefreshableCredentials.create_from_metadata(
         method = 'custom-refreshing-key-file-reader'
 )
 
-def make_key_refresh_boto3(self):
+def make_key_refresh_boto3(this_s3contents_instance):
     refresh_session =  get_session() # from botocore.session
     refresh_session._credentials = session_credentials
     my_s3_session =  boto3.Session(botocore_session=refresh_session)
-    self.boto3_session = my_s3_session
+    this_s3contents_instance.boto3_session = my_s3_session
 
 # Tell Jupyter to use S3ContentsManager for all storage.
 c.NotebookApp.contents_manager_class = S3ContentsManager

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ c.S3ContentsManager.bucket = "<bucket-name>"
 c.S3ContentsManager.prefix = "this/is/a/prefix"
 c.S3ContentsManager.sse = "AES256"
 c.S3ContentsManager.signature_version = "s3v4"
+c.S3ContentsManager.init_s3_hook = init_function # See AWS key refresh
 ```
 
 Example for `play.minio.io:9000`:
@@ -80,11 +81,51 @@ c.GCSContentsManager.token = "~/.config/gcloud/application_default_credentials.j
 c.GCSContentsManager.bucket = "<bucket-name>"
 ```
 
-## AWS IAM
+## AWS EC2 role auth setup
 
 It is also possible to use IAM Role-based access to the S3 bucket from an Amazon EC2 instance; to do that,
 just leave ```access_key_id``` and ```secret_access_key``` set to their default values (```None```), and ensure that
 the EC2 instance has an IAM role which provides sufficient permissions for the bucket and the operations necessary.
+
+## AWS key refresh
+
+The optional `init_s3_hook` configuration can be used to enable AWS key rotation (described [here](https://dev.to/li_chastina/auto-refresh-aws-tokens-using-iam-role-and-boto3-2cjf) and [here](https://www.owenrumney.co.uk/2019/01/15/implementing-refreshingawscredentials-python/)) as follows:
+
+```python
+from s3contents import S3ContentsManager
+from botocore.credentials import RefreshableCredentials
+from botocore.session import get_session
+import botocore
+import boto3
+from configparser import ConfigParser
+
+def refresh_external_credentials():
+    config = ConfigParser()
+    config.read('/home/jovyan/.aws/credentials')
+    return {
+        "access_key": config['default']['aws_access_key_id'],
+        "secret_key": config['default']['aws_secret_access_key'],
+        "token": config['default']['aws_session_token'],
+        "expiry_time": config['default']['aws_expiration']
+    }
+
+session_credentials = RefreshableCredentials.create_from_metadata(
+        metadata = refresh_external_credentials(),
+        refresh_using = refresh_external_credentials, 
+        method = 'custom-refreshing-key-file-reader'
+)
+
+def make_key_refresh_boto3(self):
+    refresh_session =  get_session() # from botocore.session
+    refresh_session._credentials = session_credentials
+    my_s3_session =  boto3.Session(botocore_session=refresh_session)
+    self.boto3_session = my_s3_session
+
+# Tell Jupyter to use S3ContentsManager for all storage.                                                                                                                            
+c.NotebookApp.contents_manager_class = S3ContentsManager
+
+c.S3ContentsManager.init_s3_hook = make_key_refresh_boto3
+```
 
 ## Access local files
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ def make_key_refresh_boto3(self):
     my_s3_session =  boto3.Session(botocore_session=refresh_session)
     self.boto3_session = my_s3_session
 
-# Tell Jupyter to use S3ContentsManager for all storage.                                                                                                                            
+# Tell Jupyter to use S3ContentsManager for all storage.
 c.NotebookApp.contents_manager_class = S3ContentsManager
 
 c.S3ContentsManager.init_s3_hook = make_key_refresh_boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ notebook
 ipykernel
 boto3
 requests
-s3fs==0.1.5
+s3fs==0.2.2
 gcsfs>=0.2.1
 nose

--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -63,6 +63,8 @@ class S3FS(GenericFS):
         default_value=None
     ).tag(config=True, env="JPYNB_S3_SESSION_TOKEN")
 
+    botocore_session = Unicode(help="Instantiated botocore obj used in place of default").tag(config=True)
+
     def __init__(self, log, **kwargs):
         super(S3FS, self).__init__(**kwargs)
         self.log = log
@@ -79,6 +81,8 @@ class S3FS(GenericFS):
             s3_additional_kwargs["ServerSideEncryption"] = self.sse
         if self.kms_key_id:
             s3_additional_kwargs["SSEKMSKeyId"]= self.kms_key_id
+        if self.botocore_session:
+            s3_additional_kwargs["session"] = self.botocore_session
 
         self.fs = s3fs.S3FileSystem(key=self.access_key_id,
                                     secret=self.secret_access_key,

--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -64,7 +64,7 @@ class S3FS(GenericFS):
         default_value=None
     ).tag(config=True, env="JPYNB_S3_SESSION_TOKEN")
 
-    botocore_session = Any(help="Instantiated botocore obj used in place of default").tag(config=True)
+    boto3_session = Any(help="Place to store customer boto3 session instance - likely passed in")
 
     def __init__(self, log, **kwargs):
         super(S3FS, self).__init__(**kwargs)
@@ -89,7 +89,7 @@ class S3FS(GenericFS):
                                     client_kwargs=client_kwargs,
                                     config_kwargs=config_kwargs,
                                     s3_additional_kwargs=s3_additional_kwargs,
-                                    session=self.botocore_session)
+                                    session=self.boto3_session)
 
         self.init()
 

--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -84,6 +84,7 @@ class S3FS(GenericFS):
             s3_additional_kwargs["SSEKMSKeyId"]= self.kms_key_id
         if self.botocore_session:
             s3_additional_kwargs["session"] = self.botocore_session
+            self.log.debug("---botocore_session was set so adding to kwargs: " + str(s3_additional_kwargs))
 
         self.fs = s3fs.S3FileSystem(key=self.access_key_id,
                                     secret=self.secret_access_key,

--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -12,6 +12,7 @@ from botocore.exceptions import ClientError
 
 from s3contents.compat import FileNotFoundError
 from s3contents.ipycompat import Unicode
+from traitlets import Any
 from s3contents.genericfs import GenericFS, NoSuchFile
 
 
@@ -63,7 +64,7 @@ class S3FS(GenericFS):
         default_value=None
     ).tag(config=True, env="JPYNB_S3_SESSION_TOKEN")
 
-    botocore_session = Unicode(help="Instantiated botocore obj used in place of default").tag(config=True)
+    botocore_session = Any(help="Instantiated botocore obj used in place of default").tag(config=True)
 
     def __init__(self, log, **kwargs):
         super(S3FS, self).__init__(**kwargs)

--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -82,16 +82,14 @@ class S3FS(GenericFS):
             s3_additional_kwargs["ServerSideEncryption"] = self.sse
         if self.kms_key_id:
             s3_additional_kwargs["SSEKMSKeyId"]= self.kms_key_id
-        if self.botocore_session:
-            s3_additional_kwargs["session"] = self.botocore_session
-            self.log.debug("---botocore_session was set so adding to kwargs: " + str(s3_additional_kwargs))
 
         self.fs = s3fs.S3FileSystem(key=self.access_key_id,
                                     secret=self.secret_access_key,
                                     token=self.session_token,
                                     client_kwargs=client_kwargs,
                                     config_kwargs=config_kwargs,
-                                    s3_additional_kwargs=s3_additional_kwargs)
+                                    s3_additional_kwargs=s3_additional_kwargs
+                                    session=self.botocore_session)
 
         self.init()
 

--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -88,7 +88,7 @@ class S3FS(GenericFS):
                                     token=self.session_token,
                                     client_kwargs=client_kwargs,
                                     config_kwargs=config_kwargs,
-                                    s3_additional_kwargs=s3_additional_kwargs
+                                    s3_additional_kwargs=s3_additional_kwargs,
                                     session=self.botocore_session)
 
         self.init()

--- a/s3contents/s3manager.py
+++ b/s3contents/s3manager.py
@@ -37,6 +37,8 @@ class S3ContentsManager(GenericContentsManager):
         default_value=None
     ).tag(config=True, env="JPYNB_S3_SESSION_TOKEN")
 
+    botocore_session = Unicode(help="Instantiated botocore obj used in place of default").tag(config=True)
+
     def __init__(self, *args, **kwargs):
         super(S3ContentsManager, self).__init__(*args, **kwargs)
 
@@ -52,7 +54,8 @@ class S3ContentsManager(GenericContentsManager):
             signature_version=self.signature_version,
             delimiter=self.delimiter,
             sse=self.sse,
-            kms_key_id= self.kms_key_id)
+            kms_key_id= self.kms_key_id,
+            botocore_session=self.botocore_session)
 
     def _save_notebook(self, model, path):
         nb_contents = from_dict(model['content'])

--- a/s3contents/s3manager.py
+++ b/s3contents/s3manager.py
@@ -37,7 +37,7 @@ class S3ContentsManager(GenericContentsManager):
         default_value=None
     ).tag(config=True, env="JPYNB_S3_SESSION_TOKEN")
 
-    botocore_session = Any(help="Instantiated botocore obj used in place of default").tag(config=True)
+    boto3_session = Any(help="Place to store custom boto3 session (passed to S3_FS) - could be set by init_s3_hook")
     init_s3_hook = Any(help="optional hook for init'ing s3").tag(config=True)
 
     def __init__(self, *args, **kwargs):
@@ -58,7 +58,7 @@ class S3ContentsManager(GenericContentsManager):
             delimiter=self.delimiter,
             sse=self.sse,
             kms_key_id= self.kms_key_id,
-            botocore_session=self.botocore_session)
+            boto3_session=self.boto3_session)
 
     def run_init_s3_hook(self):
         if self.init_s3_hook is not None:

--- a/s3contents/s3manager.py
+++ b/s3contents/s3manager.py
@@ -1,7 +1,7 @@
 import json
 
 from s3contents.ipycompat import Unicode
-
+from traitlets import Any
 from s3contents.s3_fs import S3FS
 from s3contents.genericmanager import from_dict, GenericContentsManager
 
@@ -37,10 +37,13 @@ class S3ContentsManager(GenericContentsManager):
         default_value=None
     ).tag(config=True, env="JPYNB_S3_SESSION_TOKEN")
 
-    botocore_session = Unicode(help="Instantiated botocore obj used in place of default").tag(config=True)
+    botocore_session = Any(help="Instantiated botocore obj used in place of default").tag(config=True)
+    init_s3_hook = Any(help="optional hook for init'ing s3").tag(config=True)
 
     def __init__(self, *args, **kwargs):
         super(S3ContentsManager, self).__init__(*args, **kwargs)
+
+        self.run_init_s3_hook()
 
         self._fs = S3FS(
             log=self.log,
@@ -56,6 +59,10 @@ class S3ContentsManager(GenericContentsManager):
             sse=self.sse,
             kms_key_id= self.kms_key_id,
             botocore_session=self.botocore_session)
+
+    def run_init_s3_hook(self):
+        if self.init_s3_hook is not None:
+            self.init_s3_hook(self)
 
     def _save_notebook(self, model, path):
         nb_contents = from_dict(model['content'])


### PR DESCRIPTION
The following adds a new `c.S3ContentsManager.init_s3_hook` configuration option to s3contents so that refreshing credentials can be used.  See issue #79 for more background and configuration examples