### PR TITLE
s3 read base64 format

### DIFF
--- a/s3contents/gcs_fs.py
+++ b/s3contents/gcs_fs.py
@@ -111,7 +111,7 @@ class GCSFS(GenericFS):
         self.log.debug("S3contents.GCSFS: Making dir (touch): `%s`", path_)
         self.fs.touch(path_)
 
-    def read(self, path):
+    def read(self, path, format):
         path_ = self.path(path)
         if not self.isfile(path):
             raise NoSuchFile(path_)

--- a/s3contents/genericfs.py
+++ b/s3contents/genericfs.py
@@ -28,7 +28,7 @@ class GenericFS(HasTraits):
     def mkdir(self, path):
         raise NotImplemented("Should be implemented by the file system abstraction")
 
-    def read(self, path):
+    def read(self, path, format):
         raise NotImplemented("Should be implemented by the file system abstraction")
 
     def lstat(self, path):

--- a/s3contents/genericmanager.py
+++ b/s3contents/genericmanager.py
@@ -121,7 +121,7 @@ class GenericContentsManager(ContentsManager, HasTraits):
         if content:
             if not self.fs.isfile(path):
                 self.no_such_entity(path)
-            file_content = self.fs.read(path)
+            file_content = self.fs.read(path, format)
             nb_content = reads(file_content, as_version=NBFORMAT_VERSION)
             self.mark_trusted_cells(nb_content, path)
             model["format"] = "json"
@@ -141,7 +141,7 @@ class GenericContentsManager(ContentsManager, HasTraits):
             model["last_modified"] = model["created"] = DUMMY_CREATED_DATE
         if content:
             try:
-                content = self.fs.read(path)
+                content = self.fs.read(path, format)
             except NoSuchFile as e:
                 self.no_such_entity(e.path)
             except GenericFSError as e:
@@ -149,10 +149,6 @@ class GenericContentsManager(ContentsManager, HasTraits):
             model["format"] = format or "text"
             model["content"] = content
             model["mimetype"] = mimetypes.guess_type(path)[0] or "text/plain"
-            if format == "base64":
-                model["format"] = format or "base64"
-                from base64 import b64decode
-                model["content"] = b64decode(content)
         return model
 
     def _convert_file_records(self, paths):


### PR DESCRIPTION
First commit, but really liking the library!

Fixes the UTF-8 decoding error when trying to read base64 files (eg images). Draws heavily from:
https://github.com/jupyter/notebook/blob/d0a74353e62ad5a5b0141f831c5aa59f8c2933bb/notebook/services/contents/fileio.py#L305-L320

Addresses https://github.com/danielfrg/s3contents/issues/68