### PR TITLE
Support for s3fs>=0.3.4, directory timestamp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ notifications:
   email: false
 
 python:
-  - 2.7
   - 3.5
 
 env:
@@ -18,11 +17,6 @@ env:
   - JUPYTER_VERSION="5.7"
   - JUPYTER_VERSION="5.*"
   - JUPYTER_VERSION="6.*"
-
-matrix:
-  exclude:
-  - python: 2.7
-    env: JUPYTER_VERSION="6.*"
 
 before_install:
   - pwd

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ notebook
 ipykernel
 boto3
 requests
-s3fs==0.2.2
+s3fs>=0.3.4
 gcsfs>=0.2.1
 nose

--- a/s3contents/genericmanager.py
+++ b/s3contents/genericmanager.py
@@ -100,6 +100,10 @@ class GenericContentsManager(ContentsManager, HasTraits):
     def _directory_model_from_path(self, path, content=False):
         self.log.debug("S3contents.GenericManager._directory_model_from_path: path('%s') type(%s)", path, content)
         model = base_directory_model(path)
+        if self.fs.isdir(path):
+            lstat = self.fs.lstat(path)
+            if "ST_MTIME" in lstat and lstat["ST_MTIME"]:
+                model["last_modified"] = model["created"] = lstat["ST_MTIME"]
         if content:
             if not self.dir_exists(path):
                 self.no_such_entity(path)


### PR DESCRIPTION
Tweaked to support s3fs>=0.3.4 (will not be compatible with 0.2.2, I think)
- `S3FS.isdir()` and `isfile()` call s3fs counterparts directly, instead of `s3fs.S3FileSystem.info()`. Longer explanation below..
- `touch()` doesn't seem to work in s3fs 0.3.0-0.3.3
- Call `invalidate_info()` before `info()` to force refresh, in `lstat()`

Handle directory timestamps (from the dir_keep_file)
- genericmanager tries to get timestamp for directories too
- Modified `lstat()` to look for the dir_keep_file if called on a directory

In `s3fs.S3FileSystem`, `info()` invokes a `ls()` on parent directory (via fsspec - https://github.com/intake/filesystem_spec/blob/5549f65a921b018edd2f2a0539ccbb76136125d7/fsspec/spec.py#L497). This is problematic in deployments where the AWS access policy is only for the specified prefix, causing an Access Denied error if we call `info()` on this prefix's directory. From s3fs==0.4.0 onwards `isdir()` avoids doing the `ls()` on parent directory (https://github.com/dask/s3fs/pull/259).