### PR TITLE
Fix file format

### DIFF
--- a/s3contents/gcs_fs.py
+++ b/s3contents/gcs_fs.py
@@ -117,7 +117,7 @@ class GCSFS(GenericFS):
             raise NoSuchFile(path_)
         with self.fs.open(path_, mode='rb') as f:
             content = f.read().decode("utf-8")
-        return content
+        return content, 'text'
 
     def lstat(self, path):
         path_ = self.path(path)

--- a/s3contents/genericmanager.py
+++ b/s3contents/genericmanager.py
@@ -121,7 +121,7 @@ class GenericContentsManager(ContentsManager, HasTraits):
         if content:
             if not self.fs.isfile(path):
                 self.no_such_entity(path)
-            file_content = self.fs.read(path, format)
+            file_content, _ = self.fs.read(path, format)
             nb_content = reads(file_content, as_version=NBFORMAT_VERSION)
             self.mark_trusted_cells(nb_content, path)
             model["format"] = "json"

--- a/s3contents/genericmanager.py
+++ b/s3contents/genericmanager.py
@@ -141,12 +141,13 @@ class GenericContentsManager(ContentsManager, HasTraits):
             model["last_modified"] = model["created"] = DUMMY_CREATED_DATE
         if content:
             try:
-                content = self.fs.read(path, format)
+                # Get updated format from fs.read()
+                content, format_ = self.fs.read(path, format)
             except NoSuchFile as e:
                 self.no_such_entity(e.path)
             except GenericFSError as e:
                 self.do_error(str(e), 500)
-            model["format"] = format or "text"
+            model["format"] = format_
             model["content"] = content
             model["mimetype"] = mimetypes.guess_type(path)[0] or "text/plain"
         return model

--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -194,13 +194,13 @@ class S3FS(GenericFS):
             # Try to interpret as unicode if format is unknown or if unicode
             # was explicitly requested.
             try:
-                return content.decode("utf-8")
+                return content.decode("utf-8"), 'text'
             except UnicodeError:
                 if format == 'text':
                     err = "{} is not UTF-8 encoded".format(path_)
                     self.log.error(err)
                     raise HTTPError(400, err, reason='bad format')
-        return base64.b64encode(content).decode("ascii")
+        return base64.b64encode(content).decode("ascii"), 'base64'
 
     def lstat(self, path):
         path_ = self.path(path)


### PR DESCRIPTION
Hey @danielfrg, I discovered an issue when copy/pasting binary files with s3contents, where the new file ends up being corrupted. Seems like the root cause is that `GenericContentsManager._file_model_from_path()` does not populate `model["format"]` correctly for these files. This propagates through `_get_file()` and `get()`, such that when `save()` and `_save_file()` is called the incorrect default `text` format is getting passed through to `fs.write()`.

The changes I made broadly follow the `notebook` base implementation, see:
- https://github.com/jupyter/notebook/blob/f354740e57f206d67bfb077a9f23bb8d22b6b311/notebook/services/contents/filemanager.py#L344-L374
- https://github.com/jupyter/notebook/blob/f354740e57f206d67bfb077a9f23bb8d22b6b311/notebook/services/contents/fileio.py#L293-L320