### PR TITLE
Fix prefix stripping

### DIFF
--- a/s3contents/genericmanager.py
+++ b/s3contents/genericmanager.py
@@ -101,7 +101,7 @@ class GenericContentsManager(ContentsManager, HasTraits):
 
     def _get_directory(self, path, content=True, format=None):
         self.log.debug(
-            "S3contents.GenericManager.get_directory: path('%s') content(%s) format(%s)",
+            "S3contents.GenericManager._get_directory: path('%s') content(%s) format(%s)",
             path,
             content,
             format,
@@ -110,7 +110,7 @@ class GenericContentsManager(ContentsManager, HasTraits):
 
     def _get_notebook(self, path, content=True, format=None):
         self.log.debug(
-            "S3contents.GenericManager.get_notebook: path('%s') type(%s) format(%s)",
+            "S3contents.GenericManager._get_notebook: path('%s') type(%s) format(%s)",
             path,
             content,
             format,
@@ -119,7 +119,7 @@ class GenericContentsManager(ContentsManager, HasTraits):
 
     def _get_file(self, path, content=True, format=None):
         self.log.debug(
-            "S3contents.GenericManager.get_file: path('%s') type(%s) format(%s)",
+            "S3contents.GenericManager._get_file: path('%s') type(%s) format(%s)",
             path,
             content,
             format,
@@ -213,7 +213,7 @@ class GenericContentsManager(ContentsManager, HasTraits):
     def save(self, model, path):
         """Save a file or directory model to path.
         """
-        self.log.debug("S3contents.GenericManager: save %s: '%s'", model, path)
+        self.log.debug("S3contents.GenericManager.save %s: '%s'", model, path)
         if "type" not in model:
             self.do_error("No model type provided", 400)
         if "content" not in model and model["type"] != "directory":
@@ -261,7 +261,7 @@ class GenericContentsManager(ContentsManager, HasTraits):
         actually moves a file or a directory.
         """
         self.log.debug(
-            "S3contents.GenericManager: Init rename of '%s' to '%s'", old_path, new_path
+            "S3contents.GenericManager.rename_file: Init rename of '%s' to '%s'", old_path, new_path
         )
         if self.file_exists(new_path) or self.dir_exists(new_path):
             self.already_exists(new_path)
@@ -278,7 +278,7 @@ class GenericContentsManager(ContentsManager, HasTraits):
     def delete_file(self, path):
         """Delete the file or directory at path.
         """
-        self.log.debug("S3contents.GenericManager: delete_file '%s'", path)
+        self.log.debug("S3contents.GenericManager.delete_file '%s'", path)
         if self.file_exists(path) or self.dir_exists(path):
             self.fs.rm(path)
         else:
@@ -287,7 +287,7 @@ class GenericContentsManager(ContentsManager, HasTraits):
     def is_hidden(self, path):
         """Is path a hidden directory or file?
         """
-        self.log.debug("S3contents.GenericManager: is_hidden '%s'", path)
+        self.log.debug("S3contents.GenericManager.is_hidden '%s'", path)
         return False
 
 

--- a/s3contents/genericmanager.py
+++ b/s3contents/genericmanager.py
@@ -261,7 +261,9 @@ class GenericContentsManager(ContentsManager, HasTraits):
         actually moves a file or a directory.
         """
         self.log.debug(
-            "S3contents.GenericManager.rename_file: Init rename of '%s' to '%s'", old_path, new_path
+            "S3contents.GenericManager.rename_file: Init rename of '%s' to '%s'",
+            old_path,
+            new_path,
         )
         if self.file_exists(new_path) or self.dir_exists(new_path):
             self.already_exists(new_path)

--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -234,7 +234,7 @@ class S3FS(GenericFS):
     def get_prefix(self):
         """Full prefix: bucket + optional prefix"""
         prefix = self.bucket
-        if prefix.startswith('s3://'):
+        if prefix.startswith("s3://"):
             prefix = prefix[5:]
         if self.prefix:
             prefix += self.delimiter + self.prefix

--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -119,7 +119,7 @@ class S3FS(GenericFS):
 
     def ls(self, path=""):
         path_ = self.path(path)
-        self.log.debug("S3contents.S3FS: Listing directory: `%s`", path_)
+        self.log.debug("S3contents.S3FS.ls: Listing directory: `%s`", path_)
         files = self.fs.ls(path_, refresh=True)
         return self.unprefix(files)
 
@@ -236,12 +236,13 @@ class S3FS(GenericFS):
         prefix = self.bucket
         if self.prefix:
             prefix += self.delimiter + self.prefix
-        return prefix
+        return prefix[5:]
 
     prefix_ = property(get_prefix)
 
     def unprefix(self, path):
         """Remove the self.prefix_ (if present) from a path or list of paths"""
+        self.log.debug(f'S3FS.unprefix: self.prefix_: {self.prefix_} path: {path}')
         if isinstance(path, str):
             path = path[len(self.prefix_) :] if path.startswith(self.prefix_) else path
             path = path[1:] if path.startswith(self.delimiter) else path

--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -234,9 +234,11 @@ class S3FS(GenericFS):
     def get_prefix(self):
         """Full prefix: bucket + optional prefix"""
         prefix = self.bucket
+        if prefix.startswith('s3://'):
+            prefix = prefix[5:]
         if self.prefix:
             prefix += self.delimiter + self.prefix
-        return prefix[5:]
+        return prefix
 
     prefix_ = property(get_prefix)
 

--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -242,7 +242,7 @@ class S3FS(GenericFS):
 
     def unprefix(self, path):
         """Remove the self.prefix_ (if present) from a path or list of paths"""
-        self.log.debug(f'S3FS.unprefix: self.prefix_: {self.prefix_} path: {path}')
+        self.log.debug(f"S3FS.unprefix: self.prefix_: {self.prefix_} path: {path}")
         if isinstance(path, str):
             path = path[len(self.prefix_) :] if path.startswith(self.prefix_) else path
             path = path[1:] if path.startswith(self.delimiter) else path

--- a/s3contents/s3manager.py
+++ b/s3contents/s3manager.py
@@ -79,6 +79,28 @@ class S3ContentsManager(GenericContentsManager):
 
 
 def _validate_bucket(user_bucket, log):
+    """Helper function to strip off schemas and keys from your bucket.
+
+    Another approach may be to use regexes, but then you have to 
+    think about regexes...
+
+    Parameters
+    ----------
+    user_bucket : str
+        The bucket that the user provided in their jupyter_notebook_config.py
+    log : 
+        The logger hanging off of GenericContentsManager
+    
+    Returns
+    -------
+    str
+        The properly parsed bucket out of `user_bucket`
+    
+    Raises
+    ------
+    ValueError
+        When I'm not sure how to parse out a bucket from the provided input
+    """
     log.debug(f"s3manager._validate_bucket: User provided bucket: {user_bucket}")
     res = urlparse(user_bucket)
     scheme, netloc, path, params, query, fragment = res

--- a/s3contents/s3manager.py
+++ b/s3contents/s3manager.py
@@ -7,6 +7,7 @@ from s3contents.genericmanager import GenericContentsManager, from_dict
 from s3contents.ipycompat import Unicode
 from s3contents.s3_fs import S3FS
 
+
 class S3ContentsManager(GenericContentsManager):
 
     access_key_id = Unicode(
@@ -83,24 +84,27 @@ def _validate_bucket(user_bucket, log):
     scheme, netloc, path, params, query, fragment = res
     if netloc:
         bucket = netloc
-        log.warn("s3manager._validate_bucket: "
-                f"Assuming you meant {bucket} for your bucket. "
-                f"Using that. Please set bucket={bucket} "
-                 "in your jupyter_notebook_config.py file")
+        log.warn(
+            "s3manager._validate_bucket: "
+            f"Assuming you meant {bucket} for your bucket. "
+            f"Using that. Please set bucket={bucket} "
+            "in your jupyter_notebook_config.py file"
+        )
         return bucket
     if scheme or netloc or params or query or fragment:
-        log.error("s3manager._validate_bucket: "
-                 f"Invalid bucket specification: {res}")
+        log.error("s3manager._validate_bucket: " f"Invalid bucket specification: {res}")
         raise ValueError(f"Invalid bucket specification: {res}")
-    
+
     bucket = path
-    if '/' not in bucket:
+    if "/" not in bucket:
         return bucket
-    
-    bucket, key = bucket.split('/', maxsplit=1)
-    log.warn("s3manager._validate_bucket: "
-            f"Assuming you meant {bucket} for your bucket name. Don't "
-            f"include '/' in your bucket name. Removing /{key} "
-            f"from your bucket name. Please set bucket={bucket} "
-             "in your jupyter_notebook_config.py file")
+
+    bucket, key = bucket.split("/", maxsplit=1)
+    log.warn(
+        "s3manager._validate_bucket: "
+        f"Assuming you meant {bucket} for your bucket name. Don't "
+        f"include '/' in your bucket name. Removing /{key} "
+        f"from your bucket name. Please set bucket={bucket} "
+        "in your jupyter_notebook_config.py file"
+    )
     return bucket

--- a/s3contents/s3manager.py
+++ b/s3contents/s3manager.py
@@ -81,21 +81,21 @@ class S3ContentsManager(GenericContentsManager):
 def _validate_bucket(user_bucket, log):
     """Helper function to strip off schemas and keys from your bucket.
 
-    Another approach may be to use regexes, but then you have to 
+    Another approach may be to use regexes, but then you have to
     think about regexes...
 
     Parameters
     ----------
     user_bucket : str
         The bucket that the user provided in their jupyter_notebook_config.py
-    log : 
+    log :
         The logger hanging off of GenericContentsManager
-    
+
     Returns
     -------
     str
         The properly parsed bucket out of `user_bucket`
-    
+
     Raises
     ------
     ValueError

--- a/s3contents/s3manager.py
+++ b/s3contents/s3manager.py
@@ -48,7 +48,7 @@ class S3ContentsManager(GenericContentsManager):
         super(S3ContentsManager, self).__init__(*args, **kwargs)
 
         self.run_init_s3_hook()
-
+        self.bucket = _validate_bucket(self.bucket, self.log)
         self._fs = S3FS(
             log=self.log,
             access_key_id=self.access_key_id,

--- a/s3contents/tests/test_s3manager.py
+++ b/s3contents/tests/test_s3manager.py
@@ -1,6 +1,7 @@
 import pytest
 
 from s3contents import S3ContentsManager
+from s3contents.s3manager import _validate_bucket
 from s3contents.ipycompat import TestContentsManager
 
 
@@ -37,3 +38,15 @@ class S3ContentsManagerTestCase(TestContentsManager):
 
 # This needs to be removed or else we'll run the main IPython tests as well.
 del TestContentsManager
+
+@pytest.mark.parametrize(
+    'user_bucket',
+    ("s3://BUCKET/some/key/",
+     "BUCKET/some/",
+     "BUCKET", 
+     "//BUCKET"))
+def test_bucket_validation(user_bucket, caplog):
+    import logging
+    logger = logging.getLogger()
+    validated_bucket = _validate_bucket(user_bucket, logger)
+    assert validated_bucket == 'BUCKET', "ContentsManager's bucket should be parsed properly"

--- a/s3contents/tests/test_s3manager.py
+++ b/s3contents/tests/test_s3manager.py
@@ -1,8 +1,8 @@
 import pytest
 
 from s3contents import S3ContentsManager
-from s3contents.s3manager import _validate_bucket
 from s3contents.ipycompat import TestContentsManager
+from s3contents.s3manager import _validate_bucket
 
 
 @pytest.mark.minio
@@ -39,14 +39,15 @@ class S3ContentsManagerTestCase(TestContentsManager):
 # This needs to be removed or else we'll run the main IPython tests as well.
 del TestContentsManager
 
+
 @pytest.mark.parametrize(
-    'user_bucket',
-    ("s3://BUCKET/some/key/",
-     "BUCKET/some/",
-     "BUCKET", 
-     "//BUCKET"))
+    "user_bucket", ("s3://BUCKET/some/key/", "BUCKET/some/", "BUCKET", "//BUCKET")
+)
 def test_bucket_validation(user_bucket, caplog):
     import logging
+
     logger = logging.getLogger()
     validated_bucket = _validate_bucket(user_bucket, logger)
-    assert validated_bucket == 'BUCKET', "ContentsManager's bucket should be parsed properly"
+    assert (
+        validated_bucket == "BUCKET"
+    ), "ContentsManager's bucket should be parsed properly"


### PR DESCRIPTION
Only the one line really "matters". everything else was to aid in the debugging of wtf was going on.

```
-        prefix = self.bucket
+        prefix = self.bucket.lstrip("s3://")
```

So what am I fixing here? Note two things. (1) the timestamps are all the default timestamp of 50 years ago and (2) it thinks my s3 directory is a file so if I click on it, jupyter notebook vomits up the 
404 : Not Found You are requesting a page that does not exist!" page. 
![image](https://user-images.githubusercontent.com/6223243/82454890-502f7400-9a80-11ea-90fc-dcfb96652a16.png)

Clearly that's not what we want. Doing a bit of debugging in the logs, I see the following being spit out:
```
[D 13:57:46.346 NotebookApp] 200 GET /api/sessions?_=1589982508227 (99.92.55.67) 0.89ms
[D 13:57:46.347 NotebookApp] 200 GET /api/terminals?_=1589982508228 (99.92.55.67) 1.05ms
[D 13:57:46.372 NotebookApp] S3contents.GenericManager.get] path('') type(directory) format(None)
[D 13:57:46.372 NotebookApp] S3contents.GenericManager._get_directory: path('') content(1) format(None)
[D 13:57:46.373 NotebookApp] S3contents.GenericManager._directory_model_from_path: path('') type(1)
[D 13:57:46.373 NotebookApp] S3FS.unprefix: self.prefix_: s3://BUCKET/notebooks/NO_USER path: []
[D 13:57:46.374 NotebookApp] S3contents.S3FS: `s3://BUCKET/notebooks/NO_USER` is a directory: True
[D 13:57:46.374 NotebookApp] S3FS.unprefix: self.prefix_: s3://BUCKET/notebooks/NO_USER path: []
[D 13:57:46.374 NotebookApp] S3FS.unprefix: self.prefix_: s3://BUCKET/notebooks/NO_USER path: ['.s3keep']
[D 13:57:46.422 NotebookApp] S3contents.GenericManager.dir_exists: path('')
[D 13:57:46.423 NotebookApp] S3FS.unprefix: self.prefix_: s3://BUCKET/notebooks/NO_USER path: []
[D 13:57:46.443 NotebookApp] S3contents.S3FS: `s3://BUCKET/notebooks/NO_USER` is a directory: True
[D 13:57:46.444 NotebookApp] S3FS.unprefix: self.prefix_: s3://BUCKET/notebooks/NO_USER path: []
[D 13:57:46.444 NotebookApp] S3contents.S3FS.ls: Listing directory: `s3://BUCKET/notebooks/NO_USER`
[D 13:57:46.463 NotebookApp] S3FS.unprefix: self.prefix_: s3://BUCKET/notebooks/NO_USER path: ['BUCKET/notebooks/NO_USER/.s3keep', 'BUCKET/notebooks/NO_USER/Untitled Folder', 'BUCKET/notebooks/NO_USER/Untitled.ipynb']
[D 13:57:46.464 NotebookApp] S3contents.GenericManager.dir_exists: path('BUCKET/notebooks/NO_USER/Untitled Folder')
[D 13:57:46.464 NotebookApp] S3FS.unprefix: self.prefix_: s3://BUCKET/notebooks/NO_USER path: ['BUCKET/notebooks/NO_USER/Untitled Folder']
[D 13:57:46.465 NotebookApp] S3contents.S3FS: `s3://BUCKET/notebooks/NO_USER/BUCKET/notebooks/NO_USER/Untitled Folder` is a directory: False
[D 13:57:46.465 NotebookApp] S3FS.unprefix: self.prefix_: s3://BUCKET/notebooks/NO_USER path: ['BUCKET/notebooks/NO_USER/Untitled Folder']
[D 13:57:46.466 NotebookApp] S3contents.S3FS: `s3://BUCKET/notebooks/NO_USER/BUCKET/notebooks/NO_USER/Untitled Folder` is a file: False
[D 13:57:46.467 NotebookApp] S3FS.unprefix: self.prefix_: s3://BUCKET/notebooks/NO_USER path: ['BUCKET/notebooks/NO_USER/Untitled.ipynb']
[D 13:57:46.467 NotebookApp] S3contents.S3FS: `s3://BUCKET/notebooks/NO_USER/BUCKET/notebooks/NO_USER/Untitled.ipynb` is a file: False
[D 13:57:46.468 NotebookApp] 200 GET /api/contents?type=directory&_=1589982508229 (99.92.55.67) 96.96ms
```

Pulling out some of the interesting lines, we see the following:
```
[D 13:57:46.374 NotebookApp] S3contents.S3FS: `s3://BUCKET/notebooks/NO_USER` is a directory: True
[D 13:57:46.443 NotebookApp] S3contents.S3FS: `s3://BUCKET/notebooks/NO_USER` is a directory: True
[D 13:57:46.465 NotebookApp] S3contents.S3FS: `s3://BUCKET/notebooks/NO_USER/BUCKET/notebooks/NO_USER/Untitled Folder` is a directory: False
[D 13:57:46.466 NotebookApp] S3contents.S3FS: `s3://BUCKET/notebooks/NO_USER/BUCKET/notebooks/NO_USER/Untitled Folder` is a file: False
[D 13:57:46.467 NotebookApp] S3contents.S3FS: `s3://BUCKET/notebooks/NO_USER/BUCKET/notebooks/NO_USER/Untitled.ipynb` is a file: False
```

So it seems that sometimes we're getting the directory correct and sometimes we're also doubling up on the `bucket/key`.

The additional logging in `unprefix` is what helps to explain what's going on. Here we see that unprefix is not working correctly as it's returning the following: `s3://BUCKET/KEY/BUCKET/KEY`
```
[D 13:57:46.464 NotebookApp] S3FS.unprefix: self.prefix_: s3://BUCKET/notebooks/NO_USER path: ['BUCKET/notebooks/NO_USER/Untitled Folder']
[D 13:57:46.465 NotebookApp] S3contents.S3FS: `s3://BUCKET/notebooks/NO_USER/BUCKET/notebooks/NO_USER/Untitled Folder` is a directory: False

[D 13:57:46.465 NotebookApp] S3FS.unprefix: self.prefix_: s3://BUCKET/notebooks/NO_USER path: ['BUCKET/notebooks/NO_USER/Untitled Folder']
[D 13:57:46.466 NotebookApp] S3contents.S3FS: `s3://BUCKET/notebooks/NO_USER/BUCKET/notebooks/NO_USER/Untitled Folder` is a file: False

[D 13:57:46.467 NotebookApp] S3FS.unprefix: self.prefix_: s3://BUCKET/notebooks/NO_USER path: ['BUCKET/notebooks/NO_USER/Untitled.ipynb']
[D 13:57:46.467 NotebookApp] S3contents.S3FS: `s3://BUCKET/notebooks/NO_USER/BUCKET/notebooks/NO_USER/Untitled.ipynb` is a file: False
```

So on to my hacky fix. If I strip the `s3://` from the return of `get_prefix`, then everything seems to return to normal and we get the correct timestamps and the s3 directories are properly clickable and act as folders.

Is this good enough? Are there side effects that I'm not thinking of by stripping off `s3://` from get_prefix so that `unprefix` works properly?