### PR TITLE
add file save hook support

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -17,6 +17,9 @@ Start minio in one terminal:
 make minio
 ```
 
+Note: If you are using `podman` instead of `docker`, you may have to fiddle with SELinux permissions on the volume mount for minio, or use `:z`.
+
+
 Edit local `~/.jupyter/jupyter_notebook_config.py`:
 
 ```python
@@ -28,7 +31,7 @@ c.NotebookApp.contents_manager_class = S3ContentsManager
 c.S3ContentsManager.endpoint_url = "http://localhost:9000"
 c.S3ContentsManager.access_key_id = "access-key"
 c.S3ContentsManager.secret_access_key = "secret-key"
-c.S3ContentsManager.bucket_name = "notebooks"
+c.S3ContentsManager.bucket = "notebooks"
 
 # from s3contents import GCSContentsManager
 # c.NotebookApp.contents_manager_class = GCSContentsManager

--- a/s3contents/genericmanager.py
+++ b/s3contents/genericmanager.py
@@ -43,7 +43,7 @@ class GenericContentsManager(ContentsManager, HasTraits):
         - s3_path: the S3 path to the file just written (sans bucket/prefix)
         - model: the model representing the file
         - contents_manager: this ContentsManager instance
-        """
+        """,
     )
 
     def __init__(self, *args, **kwargs):
@@ -258,7 +258,7 @@ class GenericContentsManager(ContentsManager, HasTraits):
 
         model = self.get(path, type=model["type"], content=False)
 
-        self.run_post_save_hook(model=model, s3_path=model['path'])
+        self.run_post_save_hook(model=model, s3_path=model["path"])
 
         if validation_message is not None:
             model["message"] = validation_message
@@ -318,9 +318,9 @@ class GenericContentsManager(ContentsManager, HasTraits):
         self.log.debug("S3contents.GenericManager.is_hidden '%s'", path)
         return False
 
-    @validate('post_save_hook')
+    @validate("post_save_hook")
     def _validate_post_save_hook(self, proposal):
-        value = proposal['value']
+        value = proposal["value"]
         if isinstance(value, string_types):
             value = import_item(value)
         if not callable(value):
@@ -332,13 +332,12 @@ class GenericContentsManager(ContentsManager, HasTraits):
         if self.post_save_hook:
             try:
                 self.log.debug("Running post-save hook on %s", s3_path)
-                self.post_save_hook(
-                    s3_path=s3_path, model=model, contents_manager=self)
+                self.post_save_hook(s3_path=s3_path, model=model, contents_manager=self)
             except Exception as e:
-                self.log.error("Post-save hook failed o-n %s",
-                               s3_path, exc_info=True)
-                raise HTTPError(500, u'Unexpected error while running post hook save: %s'
-                                % e) from e
+                self.log.error("Post-save hook failed o-n %s", s3_path, exc_info=True)
+                raise HTTPError(
+                    500, "Unexpected error while running post hook save: %s" % e
+                ) from e
 
 
 def base_model(path):

--- a/s3contents/genericmanager.py
+++ b/s3contents/genericmanager.py
@@ -241,10 +241,10 @@ class GenericContentsManager(ContentsManager, HasTraits):
             self.do_error("Unexpected error while saving file: %s %s" % (path, e), 500)
 
         model = self.get(path, type=model["type"], content=False)
-        
+
         # os_path in this case is s3 API path
         self.run_post_save_hook(model=model, os_path=model['path'])
-        
+
         if validation_message is not None:
             model["message"] = validation_message
         return model
@@ -303,8 +303,10 @@ class GenericContentsManager(ContentsManager, HasTraits):
         self.log.debug("S3contents.GenericManager.is_hidden '%s'", path)
         return False
 
-    
-    post_save_hook = Any(None, config=True, allow_none=True,
+    post_save_hook = Any(
+        None,
+        config=True,
+        allow_none=True,
         help="""Python callable or importstring thereof
         to be called on the path of a file just saved.
         This can be used to process the file on disk,
@@ -331,11 +333,13 @@ class GenericContentsManager(ContentsManager, HasTraits):
         if self.post_save_hook:
             try:
                 self.log.debug("Running post-save hook on %s", os_path)
-                self.post_save_hook(os_path=os_path, model=model, contents_manager=self)
+                self.post_save_hook(
+                    os_path=os_path, model=model, contents_manager=self)
             except Exception as e:
-                self.log.error("Post-save hook failed o-n %s", os_path, exc_info=True)
+                self.log.error("Post-save hook failed o-n %s",
+                               os_path, exc_info=True)
                 raise HTTPError(500, u'Unexpected error while running post hook save: %s'
-                                    % e) from e
+                                % e) from e
 
 
 def base_model(path):

--- a/s3contents/genericmanager.py
+++ b/s3contents/genericmanager.py
@@ -7,17 +7,17 @@ from tornado.web import HTTPError
 
 from s3contents.genericfs import GenericFSError, NoSuchFile
 from s3contents.ipycompat import (
+    Any,
     ContentsManager,
     GenericFileCheckpoints,
     HasTraits,
     TraitError,
-    import_item,
     Unicode,
-    Any,
     from_dict,
+    import_item,
     reads,
+    string_types,
     validate,
-    string_types
 )
 
 

--- a/s3contents/ipycompat.py
+++ b/s3contents/ipycompat.py
@@ -59,5 +59,6 @@ __all__ = [
     "string_types",
     "strip_transient",
     "to_os_path",
+    "validate",
     "writes",
 ]

--- a/s3contents/ipycompat.py
+++ b/s3contents/ipycompat.py
@@ -20,7 +20,10 @@ from notebook.services.contents.tests.test_contents_api import APITest
 from notebook.services.contents.tests.test_manager import TestContentsManager
 from notebook.tests.launchnotebook import assert_http_error
 from notebook.utils import to_os_path
-from traitlets import Any, Bool, Dict, HasTraits, Instance, Integer, Unicode
+from ipython_genutils.py3compat import string_types
+from ipython_genutils.importstring import import_item
+
+from traitlets import Any, Bool, Dict, HasTraits, Instance, Integer, Unicode, TraitError, validate
 from traitlets.config import Config
 
 
@@ -44,13 +47,16 @@ __all__ = [
     "Instance",
     "Integer",
     "TestContentsManager",
+    "TraitError",
     "Unicode",
     "from_dict",
+    "import_item",
     "new_code_cell",
     "new_markdown_cell",
     "new_notebook",
     "new_raw_cell",
     "reads",
+    "string_types",
     "strip_transient",
     "to_os_path",
     "writes",

--- a/s3contents/ipycompat.py
+++ b/s3contents/ipycompat.py
@@ -4,6 +4,8 @@ Utilities for managing compat between notebook versions.
 Taken from: https://github.com/quantopian/pgcontents/blob/master/pgcontents/utils/ipycompat.py
 """
 
+from ipython_genutils.importstring import import_item
+from ipython_genutils.py3compat import string_types
 from nbformat import from_dict, reads, writes
 from nbformat.v4.nbbase import (
     new_code_cell,
@@ -20,10 +22,17 @@ from notebook.services.contents.tests.test_contents_api import APITest
 from notebook.services.contents.tests.test_manager import TestContentsManager
 from notebook.tests.launchnotebook import assert_http_error
 from notebook.utils import to_os_path
-from ipython_genutils.py3compat import string_types
-from ipython_genutils.importstring import import_item
-
-from traitlets import Any, Bool, Dict, HasTraits, Instance, Integer, Unicode, TraitError, validate
+from traitlets import (
+    Any,
+    Bool,
+    Dict,
+    HasTraits,
+    Instance,
+    Integer,
+    TraitError,
+    Unicode,
+    validate,
+)
 from traitlets.config import Config
 
 

--- a/s3contents/tests/hooks.py
+++ b/s3contents/tests/hooks.py
@@ -1,20 +1,22 @@
 import os
+
 import nbformat
+
 
 def scrub_output_pre_save(model, **kwargs):
     """scrub output before saving notebooks"""
     # only run on notebooks
-    if model['type'] != 'notebook':
+    if model["type"] != "notebook":
         return
     # only run on nbformat v4
-    if model['content']['nbformat'] != 4:
+    if model["content"]["nbformat"] != 4:
         return
 
-    for cell in model['content']['cells']:
-        if cell['cell_type'] != 'code':
+    for cell in model["content"]["cells"]:
+        if cell["cell_type"] != "code":
             continue
-        cell['outputs'] = []
-        cell['execution_count'] = None
+        cell["outputs"] = []
+        cell["execution_count"] = None
 
 
 def make_html_post_save(model, s3_path, contents_manager, **kwargs):
@@ -23,16 +25,16 @@ def make_html_post_save(model, s3_path, contents_manager, **kwargs):
     """
     from nbconvert import HTMLExporter
 
-    if model['type'] != 'notebook':
+    if model["type"] != "notebook":
         return
 
     content, _format = contents_manager.fs.read(s3_path, format="text")
     my_notebook = nbformat.reads(content, as_version=4)
 
     html_exporter = HTMLExporter()
-    html_exporter.template_name = 'classic'
+    html_exporter.template_name = "classic"
 
     (body, resources) = html_exporter.from_notebook_node(my_notebook)
 
     base, ext = os.path.splitext(s3_path)
-    contents_manager.fs.write(path=(base + '.html'), content=body, format=_format)
+    contents_manager.fs.write(path=(base + ".html"), content=body, format=_format)

--- a/s3contents/tests/hooks.py
+++ b/s3contents/tests/hooks.py
@@ -19,7 +19,7 @@ def scrub_output_pre_save(model, **kwargs):
 
 def make_html_post_save(model, s3_path, contents_manager, **kwargs):
     """
-    convert notebooks to HTML after save with nbconvert
+    convert notebooks to HTML after saving via nbconvert
     """
     from nbconvert import HTMLExporter
 

--- a/s3contents/tests/hooks.py
+++ b/s3contents/tests/hooks.py
@@ -1,0 +1,38 @@
+import os
+import nbformat
+
+def scrub_output_pre_save(model, **kwargs):
+    """scrub output before saving notebooks"""
+    # only run on notebooks
+    if model['type'] != 'notebook':
+        return
+    # only run on nbformat v4
+    if model['content']['nbformat'] != 4:
+        return
+
+    for cell in model['content']['cells']:
+        if cell['cell_type'] != 'code':
+            continue
+        cell['outputs'] = []
+        cell['execution_count'] = None
+
+
+def make_html_post_save(model, s3_path, contents_manager, **kwargs):
+    """
+    convert notebooks to HTML after save with nbconvert
+    """
+    from nbconvert import HTMLExporter
+
+    if model['type'] != 'notebook':
+        return
+
+    content, _format = contents_manager.fs.read(s3_path, format="text")
+    my_notebook = nbformat.reads(content, as_version=4)
+
+    html_exporter = HTMLExporter()
+    html_exporter.template_name = 'classic'
+
+    (body, resources) = html_exporter.from_notebook_node(my_notebook)
+
+    base, ext = os.path.splitext(s3_path)
+    contents_manager.fs.write(path=(base + '.html'), content=body, format=_format)

--- a/s3contents/tests/test_s3manager.py
+++ b/s3contents/tests/test_s3manager.py
@@ -48,30 +48,31 @@ class S3ContentsManagerTestCase(TestContentsManager):
         self.contents_manager.post_save_hook = make_html_post_save
 
         cm = self.contents_manager
-        model = cm.new_untitled(type='notebook')
-        path = model['path']
+        model = cm.new_untitled(type="notebook")
+        path = model["path"]
 
         full_model = cm.get(path)
-        nb = full_model['content']
-        nb['metadata']['counter'] = int(1e6 * time.time())
+        nb = full_model["content"]
+        nb["metadata"]["counter"] = int(1e6 * time.time())
         self.add_code_cell(nb)
 
         cm.save(full_model, path)
 
         # test pre_save_hook
         loaded_model = cm.get(path)
-        for cell in loaded_model['content']['cells']:
-            assert cell['outputs'] == []
+        for cell in loaded_model["content"]["cells"]:
+            assert cell["outputs"] == []
 
         # test post_save_hook
-        html_file = os.path.splitext(path)[0] + '.html'
-        html, _type = cm.fs.read(html_file, 'text')
+        html_file = os.path.splitext(path)[0] + ".html"
+        html, _type = cm.fs.read(html_file, "text")
 
         assert cm.fs.isfile(html_file)
-        assert '<!DOCTYPE html>' in html
+        assert "<!DOCTYPE html>" in html
 
         self.contents_manager.pre_save_hook = None
         self.contents_manager.post_save_hook = None
+
 
 # This needs to be removed or else we'll run the main IPython tests as well.
 del TestContentsManager

--- a/s3contents/tests/test_s3manager.py
+++ b/s3contents/tests/test_s3manager.py
@@ -1,8 +1,12 @@
+import os
+import time
+
 import pytest
 
 from s3contents import S3ContentsManager
 from s3contents.ipycompat import TestContentsManager
 from s3contents.s3manager import _validate_bucket
+from s3contents.tests.hooks import make_html_post_save, scrub_output_pre_save
 
 
 @pytest.mark.minio
@@ -34,6 +38,41 @@ class S3ContentsManagerTestCase(TestContentsManager):
         self.contents_manager.new(
             model={"type": "directory"}, path=api_path,
         )
+
+
+    def test_save_hooks(self):
+        """
+        Extends TestContentsManager.save
+        """
+
+        self.contents_manager.pre_save_hook = scrub_output_pre_save
+        self.contents_manager.post_save_hook = make_html_post_save 
+
+        cm = self.contents_manager
+        model = cm.new_untitled(type='notebook')
+        path = model['path']
+
+        full_model = cm.get(path)
+        nb = full_model['content']
+        nb['metadata']['counter'] = int(1e6 * time.time())
+        self.add_code_cell(nb)
+
+        cm.save(full_model, path)
+
+        # test pre_save_hook 
+        loaded_model = cm.get(path)
+        for cell in loaded_model['content']['cells']:
+            assert cell['outputs'] == []
+
+        # test post_save_hook
+        html_file = os.path.splitext(path)[0] + '.html'
+        html, _type = cm.fs.read(html_file, 'text')
+        
+        assert cm.fs.isfile(html_file)
+        assert '<!DOCTYPE html>' in html
+
+        self.contents_manager.pre_save_hook = None
+        self.contents_manager.post_save_hook = None
 
 
 # This needs to be removed or else we'll run the main IPython tests as well.

--- a/s3contents/tests/test_s3manager.py
+++ b/s3contents/tests/test_s3manager.py
@@ -39,14 +39,13 @@ class S3ContentsManagerTestCase(TestContentsManager):
             model={"type": "directory"}, path=api_path,
         )
 
-
     def test_save_hooks(self):
         """
         Extends TestContentsManager.save
         """
 
         self.contents_manager.pre_save_hook = scrub_output_pre_save
-        self.contents_manager.post_save_hook = make_html_post_save 
+        self.contents_manager.post_save_hook = make_html_post_save
 
         cm = self.contents_manager
         model = cm.new_untitled(type='notebook')
@@ -59,7 +58,7 @@ class S3ContentsManagerTestCase(TestContentsManager):
 
         cm.save(full_model, path)
 
-        # test pre_save_hook 
+        # test pre_save_hook
         loaded_model = cm.get(path)
         for cell in loaded_model['content']['cells']:
             assert cell['outputs'] == []
@@ -67,13 +66,12 @@ class S3ContentsManagerTestCase(TestContentsManager):
         # test post_save_hook
         html_file = os.path.splitext(path)[0] + '.html'
         html, _type = cm.fs.read(html_file, 'text')
-        
+
         assert cm.fs.isfile(html_file)
         assert '<!DOCTYPE html>' in html
 
         self.contents_manager.pre_save_hook = None
         self.contents_manager.post_save_hook = None
-
 
 # This needs to be removed or else we'll run the main IPython tests as well.
 del TestContentsManager


### PR DESCRIPTION
This fixes #70 and #65, basically just ported over the `FileSystemContentsManager` implementations from upstream notebook.

Tested the following hooks locally with `minio`: 

```py
def scrub_output_pre_save(model, **kwargs):
    """scrub output before saving notebooks"""
    # only run on notebooks
    if model['type'] != 'notebook':
        return
    # only run on nbformat v4
    if model['content']['nbformat'] != 4:
        return

    for cell in model['content']['cells']:
        if cell['cell_type'] != 'code':
            continue
        cell['outputs'] = []
        cell['execution_count'] = None

c.S3ContentsManager.pre_save_hook = scrub_output_pre_save
```

Post save hooks are a little tricky to write, but I was able to get one to work that runs `nbconvert` and saves the notebook as HTML by reusing `contents_manager.fs`. I treated the `os_path` from the hook function as essentially the S3 API path:

```py
import os
import nbformat

def make_html_post_save(model, os_path, contents_manager, **kwargs):
    """
    convert notebooks to HTML after save with nbconvert
    """
    from nbconvert import HTMLExporter

    if model['type'] != 'notebook':
        return

    content, _format = contents_manager.fs.read(os_path, format="text")
    my_notebook = nbformat.reads(content, as_version=4)

    html_exporter = HTMLExporter()
    html_exporter.template_name = 'classic'

    (body, resources) = html_exporter.from_notebook_node(my_notebook)

    base, ext = os.path.splitext(os_path)
    contents_manager.fs.write(path=(base + '.html'), content=body, format=_format)

c.S3ContentsManager.post_save_hook = make_html_post_save
```


