### PR TITLE
GCS bugfixes

### DIFF
--- a/s3contents/genericmanager.py
+++ b/s3contents/genericmanager.py
@@ -327,7 +327,8 @@ class GenericContentsManager(ContentsManager, HasTraits):
         nb_contents = from_dict(model["content"])
         self.check_and_sign(nb_contents, path)
         file_contents = json.dumps(model["content"])
-        self.fs.write(path, file_contents)
+        file_format = model.get("format")
+        self.fs.write(path, file_contents, file_format)
         self.validate_notebook_model(model)
         return model.get("message")
 

--- a/s3contents/genericmanager.py
+++ b/s3contents/genericmanager.py
@@ -181,7 +181,7 @@ class GenericContentsManager(ContentsManager, HasTraits):
         if self.fs.isfile(path):
             model["last_modified"] = model["created"] = self.fs.lstat(path)["ST_MTIME"]
         else:
-            model["last_modified"] = model["created"] = DUMMY_CREATED_DATE
+            self.do_error("Not Found", 404)
         if content:
             if not self.fs.isfile(path):
                 self.no_such_entity(path)


### PR DESCRIPTION
This PR fixes various issues we encountered using s3contents in combination with GCS (each issue is in a separate commit):

- _GenericContentsManager#_save_notebook_ did not pass the notebook format to _GenericFS#write_
- _gcsfs_ apparently changed their API
- Previously only _text_ format was supported for reading/writing. _TestContentsManager#test_get_ explicitly tests for base64 encoded, therefore base64 encoded was added as a supported format.
- Fix "Save As" button behaviour in Jupyter Notebook.

This PR should also fix #62 (not sure about this one...).

Just a general remark: The requirements in _requirements.txt_ do not have a version number given. I think it would be a good idea to explicitly fix the versions. We tested all changes in this PR using

notebook==6.1.4
requests==2.24.0
boto3==1.14.62
s3fs==0.5.1
gcsfs==0.7.1
mock==4.0.2

Please let me know, if you prefer separate PRs for each issue