### PR TITLE
Fix issue https://github.com/danielfrg/s3contents/issues/113

### DIFF
--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -4,6 +4,7 @@ Utilities to make S3 look like a regular file system
 import base64
 import os
 import sys
+import re
 
 import s3fs
 from botocore.exceptions import ClientError
@@ -74,7 +75,7 @@ class S3FS(GenericFS):
         self.log = log
 
         client_kwargs = {
-            "endpoint_url": self.endpoint_url,
+            "endpoint_url": None if re.match(r"^s3://arn:(aws).*:s3:[a-z\-0-9]+:[0-9]{12}:accesspoint[:/]\S+$", self.bucket) else self.endpoint_url,
             "region_name": self.region_name,
         }
         config_kwargs = {}


### PR DESCRIPTION
Make s3content compatible with [Amazon S3 Access Point](https://aws.amazon.com/s3/features/access-points/).

The S3 access point regex is copied from [BotoCore](https://github.com/boto/botocore/blob/develop/botocore/handlers.py#L64-L65), which is the foundation for the AWS CLI as well as boto3 (AWS Python SDK).