### PR TITLE
Added upper bound version requirement for 'fsspec' and 'gcsfs'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 notebook>=5.6,<7.0
+fsspec<=0.8.7
 s3fs>=0.3.4,<0.5.1
-gcsfs>=0.2.1
+gcsfs>=0.2.1,<0.8.0
 requests
 requests_unixsocket
 boto3


### PR DESCRIPTION
This PR addresses the issue introduced by now versions of dependency libraries 'fsspec' and 'gcsfs'
https://github.com/danielfrg/s3contents/issues/118