### PR TITLE
add skip_tls_verify flag to support self-signed CA

### DIFF
--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -14,7 +14,7 @@ from tornado.web import HTTPError
 from traitlets import Any
 
 from s3contents.genericfs import GenericFS, NoSuchFile
-from s3contents.ipycompat import Unicode
+from s3contents.ipycompat import Unicode, Bool
 
 SAMPLE_ACCESS_POLICY = """
 {{
@@ -47,6 +47,9 @@ class S3FS(GenericFS):
     )
     bucket = Unicode("notebooks", help="Bucket name to store notebooks").tag(
         config=True, env="JPYNB_S3_BUCKET"
+    )
+    skip_tls_verify = Bool(False, help="Skip endpoint tls verify").tag(
+        config=True, env="JPYNB_S3_SKIP_TLS_VERIFY"
     )
     signature_version = Unicode(help="").tag(config=True)
     sse = Unicode(help="Type of server-side encryption to use").tag(
@@ -90,6 +93,8 @@ class S3FS(GenericFS):
             else self.endpoint_url,
             "region_name": self.region_name,
         }
+        if self.skip_tls_verify:
+            client_kwargs.update({"verify": False})
         config_kwargs = {}
         if self.signature_version:
             config_kwargs["signature_version"] = self.signature_version

--- a/s3contents/s3manager.py
+++ b/s3contents/s3manager.py
@@ -32,6 +32,10 @@ class S3ContentsManager(GenericContentsManager):
         "https://s3.amazonaws.com", help="S3 endpoint URL"
     ).tag(config=True, env="JPY_S3_ENDPOINT_URL")
 
+    skip_tls_verify = Bool(False, help="Skip endpoint tls verify").tag(
+        config=True, env="JPYNB_S3_SKIP_TLS_VERIFY"
+    )
+
     kms_key_id = Unicode(help="KMS ID to use to encrypt workbooks").tag(
         config=True, env="JPY_S3_KMS_KEY_ID"
     )
@@ -79,6 +83,7 @@ class S3ContentsManager(GenericContentsManager):
             bucket=self.bucket,
             delimiter=self.delimiter,
             endpoint_url=self.endpoint_url,
+            skip_tls_verify=self.skip_tls_verify,
             kms_key_id=self.kms_key_id,
             log=self.log,
             prefix=self.prefix,


### PR DESCRIPTION
After trying multiple methods I still hadn't gotten around the certificate authentication issue, so I added a flag bit to quickly support the scenario of using self-signed certificates internally.

Please help to evaluate if this change is necessary and if maybe I'm using it in the wrong way.