### PR TITLE
Prioritize jupyter_server import over notebook

### DIFF
--- a/s3contents/ipycompat.py
+++ b/s3contents/ipycompat.py
@@ -12,31 +12,31 @@ from nbformat.v4.nbbase import (
 )
 from nbformat.v4.rwbase import strip_transient
 
-# Pick dependencies from either notebook (notebook version<=6) or jupyter_server (jupyterlab, notebook>=7)
+# Pick dependencies from jupyter_server (jupyterlab, notebook>=7) but fallback to notebook (notebook version<=6)
 ct_mgr_deps_loaded = False
 try:
-    from notebook.services.contents.checkpoints import (
-      Checkpoints,
-      GenericCheckpointsMixin,
+    from jupyter_server.services.contents.checkpoints import (
+        Checkpoints,
+        GenericCheckpointsMixin,
     )
-    from notebook.services.contents.filecheckpoints import GenericFileCheckpoints
-    from notebook.services.contents.filemanager import FileContentsManager
-    from notebook.services.contents.manager import ContentsManager
-    from notebook.base.handlers import AuthenticatedFileHandler
+    from jupyter_server.services.contents.filecheckpoints import GenericFileCheckpoints
+    from jupyter_server.services.contents.filemanager import FileContentsManager
+    from jupyter_server.services.contents.manager import ContentsManager
+    from jupyter_server.base.handlers import AuthenticatedFileHandler
     ct_mgr_deps_loaded = True
 except ModuleNotFoundError:
     pass
 
 if not ct_mgr_deps_loaded:
     try:
-        from jupyter_server.services.contents.checkpoints import (
-          Checkpoints,
-          GenericCheckpointsMixin,
+        from notebook.services.contents.checkpoints import (
+            Checkpoints,
+            GenericCheckpointsMixin,
         )
-        from jupyter_server.services.contents.filecheckpoints import GenericFileCheckpoints
-        from jupyter_server.services.contents.filemanager import FileContentsManager
-        from jupyter_server.services.contents.manager import ContentsManager
-        from jupyter_server.base.handlers import AuthenticatedFileHandler
+        from notebook.services.contents.filecheckpoints import GenericFileCheckpoints
+        from notebook.services.contents.filemanager import FileContentsManager
+        from notebook.services.contents.manager import ContentsManager
+        from notebook.base.handlers import AuthenticatedFileHandler
         ct_mgr_deps_loaded = True
     except ModuleNotFoundError:
         pass


### PR DESCRIPTION
I am using the `jupyterhub/single_user` docker image that includes both notebook and jupyter_server. On start up I get the error:

```
    traitlets.traitlets.TraitError: The 'contents_manager_class' trait of a ServerApp instance expected a subclass of 'jupyter_server.services.contents.manager.ContentsManager', not the S3ContentsManager S3ContentsManager.
```

I find that S3ContentsManager is type `notebook.services.contents.manager.ContentsManager` instead because the import of notebook.* didn't fail.

I'm not an expert on the relationship between jupyterlab/server/notebook, but I don't know a situation where you would use notebook while server is also installed