### PR TITLE
update GenericContentsManager to allow use of jupyter_server 2.11+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         # os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.9, "3.10", 3.11, 3.12]
+        python-version: [3.9, "3.10", 3.11]
         jupyter-version: ["6.3", "6.4", "6.*", "7.1", "7.*"]
 
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         # os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.9, "3.10", 3.11]
+        python-version: [3.9, "3.10", 3.11, 3.12]
         jupyter-version: ["6.3", "6.4", "6.*", "7.1", "7.*"]
 
     runs-on: ubuntu-latest

--- a/s3contents/gcs/gcs_fs.py
+++ b/s3contents/gcs/gcs_fs.py
@@ -123,14 +123,14 @@ class GCSFS(GenericFS):
         if not self.isfile(path):
             raise NoSuchFile(path_)
         with self.fs.open(path_, mode="rb") as f:
-            content = f.read()
+            raw_content = f.read()
         if format == "base64":
-            return base64.b64encode(content).decode("ascii"), "base64"
+            return base64.b64encode(raw_content).decode("ascii"), "base64", raw_content
         else:
             # Try to interpret as unicode if format is unknown or if unicode
             # was explicitly requested.
             try:
-                return content.decode("utf-8"), "text"
+                return raw_content.decode("utf-8"), "text", raw_content
             except UnicodeError:
                 if format == "text":
                     err = "{} is not UTF-8 encoded".format(path_)

--- a/s3contents/ipycompat.py
+++ b/s3contents/ipycompat.py
@@ -52,7 +52,7 @@ if not ct_mgr_deps_loaded:
 
 if not ct_mgr_deps_loaded:
     raise ImportError(
-        "Couldn't import ContentsManager from either nootebook or jupyter_server."
+        "Couldn't import ContentsManager from either notebook or jupyter_server."
         "Make sure that Jupyter Notebook or JupyterLab package is installed."
     )
 

--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -207,19 +207,19 @@ class S3FS(GenericFS):
         if not self.isfile(path):
             raise NoSuchFile(path_)
         with self.fs.open(path_, mode="rb") as f:
-            content = f.read()
+            raw_content = f.read()
         # format is not base64-encoded. "json" is requested by jupyter collaboration.
         if format is None or format in ["text", "json"]:
             # Try to interpret as unicode if format is unknown or if unicode
             # was explicitly requested.
             try:
-                return content.decode("utf-8"), "text"
+                return raw_content.decode("utf-8"), "text"
             except UnicodeError:
                 if format == "text":
                     err = "{} is not UTF-8 encoded".format(path_)
                     self.log.error(err)
                     raise HTTPError(400, err, reason="bad format")
-        return base64.b64encode(content).decode("ascii"), "base64"
+        return base64.b64encode(raw_content).decode("ascii"), "base64", raw_content
 
     def lstat(self, path):
         path_ = self.path(path)

--- a/s3contents/s3_fs.py
+++ b/s3contents/s3_fs.py
@@ -213,7 +213,7 @@ class S3FS(GenericFS):
             # Try to interpret as unicode if format is unknown or if unicode
             # was explicitly requested.
             try:
-                return raw_content.decode("utf-8"), "text"
+                return raw_content.decode("utf-8"), "text", raw_content
             except UnicodeError:
                 if format == "text":
                     err = "{} is not UTF-8 encoded".format(path_)

--- a/s3contents/tests/hooks.py
+++ b/s3contents/tests/hooks.py
@@ -32,7 +32,7 @@ def make_html_post_save(model, s3_path, contents_manager, **kwargs):
     if model["type"] != "notebook":
         return
 
-    content, _format = contents_manager.fs.read(s3_path, format="text")
+    content, _format, _ = contents_manager.fs.read(s3_path, format="text")
     my_notebook = nbformat.reads(content, as_version=4)
 
     html_exporter = HTMLExporter()

--- a/s3contents/tests/test_s3manager.py
+++ b/s3contents/tests/test_s3manager.py
@@ -66,7 +66,7 @@ class S3ContentsManagerTestCase(TestContentsManager):
 
         # test post_save_hook
         html_file = os.path.splitext(path)[0] + ".html"
-        html, _type = cm.fs.read(html_file, "text")
+        html, _type, _ = cm.fs.read(html_file, "text")
 
         assert cm.fs.isfile(html_file)
         assert "<!DOCTYPE html>" in html


### PR DESCRIPTION
Since jupyter_server 2.11+, the `get(...)` method of `ContentsManager` has an extra `require_hash` argument.

Current implementation throws exception like:

```
TypeError("GenericContentsManager.get() got an unexpected keyword argument 'require_hash'")
    Traceback (most recent call last):
      File "/home/jupyter/.local/lib/python3.10/site-packages/jupyter_server_ydoc/rooms.py", line 308, in _maybe_save_document
        saved_model = await self._file.maybe_save_content(
      File "/home/jupyter/.local/lib/python3.10/site-packages/jupyter_server_ydoc/loaders.py", line 168, in maybe_save_content
        saved_model = await asyncio.shield(task)
      File "/home/jupyter/.local/lib/python3.10/site-packages/jupyter_server_ydoc/loaders.py", line 187, in _save_content
        self._contents_manager.get(
    TypeError: GenericContentsManager.get() got an unexpected keyword argument 'require_hash'
```

Handling this argument in `GenericContentsManager` should solve this.

Fixes #200 